### PR TITLE
ci: pin actions to commit SHAs and restrict permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   linters:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
-      - uses: golangci/golangci-lint-action@v9.2.0
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.3
           args: --timeout 3m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,31 +4,32 @@ on:
       - v*
   workflow_dispatch:
 
-permissions:
-  # To upload archives as GitHub Releases
-  contents: write
-  # To push Docker images to GitHub
-  packages: write
+permissions: {}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      # To upload archives as GitHub Releases
+      contents: write
+      # To push Docker images to GitHub
+      packages: write
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # All history, required for goreleaser
           fetch-depth: 0
       - # For TagBody, TagSubject or TagContents fields in goreleaser's templates
         run: git fetch --force --tags
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           version: v2.15.2
           args: release --clean

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
       - run: go test -race ./...


### PR DESCRIPTION
Actions pinned to mutable tags are vulnerable to tag-moving supply chain attacks.

- Pin all actions to their current commit SHA (tag kept as comment)
- Move `permissions` from workflow level to job level in release.yml (was already partially set)
- Add `permissions: {}` at workflow level + `contents: read` for lint and tests jobs