### PR TITLE
ci: add govulncheck and dependency-review workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,3 +17,6 @@ jobs:
         with:
           go-version: 1.25.x
       - run: go test -race ./...
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          repo-checkout: false


### PR DESCRIPTION
Adds two supply chain hardening checks:

- `govulncheck` runs on every push/PR — checks reachable code for known CVEs (golang.org/x/vuln)
- `dependency-review-action` runs on PRs — flags new dependencies with known vulnerabilities or license changes

Both pinned to commit hashes.